### PR TITLE
HDDS-13260. Add smoke test for bucket owner condition

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -373,3 +373,43 @@ Test Multipart Upload list
         ${uploadID}=    Get From List    ${uploadIDs}    ${index}
         Abort MPU    ${BUCKET}    ${key}    ${uploadID}    0
     END
+
+Check Bucket Ownership Verification
+    # 1. InitMultipartUpload
+    Execute AWSS3APICli and failed bucket ownership verification  create-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/mpu/key1  wrong-owner
+    ${correct_owner}=    Get bucket owner    ${BUCKET}
+    ${uploadID}=         Execute AWSS3APICli using bucket ownership verification   create-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/mpu/key1    ${correct_owner}
+    ${uploadID}=         Execute and checkrc                                       echo '${uploadID}' | jq -r '.UploadId'    0
+
+    # 2. upload-part
+    Execute AWSS3APICli and failed bucket ownership verification                   upload-part --bucket ${BUCKET} --key ${PREFIX}/mpu/key1 --part-number 1 --body /tmp/part1 --upload-id ${uploadID}  wrong-owner
+    ${ETag1} =  Execute AWSS3APICli using bucket ownership verification            upload-part --bucket ${BUCKET} --key ${PREFIX}/mpu/key1 --part-number 1 --body /tmp/part1 --upload-id ${uploadID}  ${correct_owner}
+    ${ETag1} =  Execute and checkrc                                                echo '${ETag1}' | jq -r '.ETag'    0
+
+
+    # 3. upload-part-copy
+    ${result}=    Execute AWSS3APICli                                              put-object --bucket ${BUCKET} --key ${PREFIX}/mpu/source --body /tmp/part2
+    Execute AWSS3APICli and failed bucket ownership verification                   upload-part-copy --bucket ${BUCKET} --key ${PREFIX}/mpu/key1 --upload-id ${uploadID} --part-number 2 --copy-source ${BUCKET}/${PREFIX}/mpu/source  ${correct_owner}  wrong-owner
+    Execute AWSS3APICli and failed bucket ownership verification                   upload-part-copy --bucket ${BUCKET} --key ${PREFIX}/mpu/key1 --upload-id ${uploadID} --part-number 2 --copy-source ${BUCKET}/${PREFIX}/mpu/source  wrong-owner       ${correct_owner}
+    ${ETag2} =  Execute AWSS3APICli using bucket ownership verification            upload-part-copy --bucket ${BUCKET} --key ${PREFIX}/mpu/key1 --upload-id ${uploadID} --part-number 2 --copy-source ${BUCKET}/${PREFIX}/mpu/source  ${correct_owner}  ${correct_owner}
+    ${ETag2} =  Execute and checkrc                                                echo '${ETag2}' | jq -r '.CopyPartResult.ETag'    0
+
+    # 4. list-multipart-uploads
+    Execute AWSS3APICli and failed bucket ownership verification                   list-multipart-uploads --bucket ${BUCKET}  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification                        list-multipart-uploads --bucket ${BUCKET}  ${correct_owner}
+
+    # 5. list-parts
+    Execute AWSS3APICli and failed bucket ownership verification                   list-parts --bucket ${BUCKET} --key ${PREFIX}/mpu/key1 --upload-id ${uploadID}  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification                        list-parts --bucket ${BUCKET} --key ${PREFIX}/mpu/key1 --upload-id ${uploadID}  ${correct_owner}
+
+    # 6. complete-multipart-upload
+    ${parts}=    Set Variable                                                      {ETag=${ETag1},PartNumber=1},{ETag=${ETag2},PartNumber=2}
+    Execute AWSS3APICli and failed bucket ownership verification                   complete-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/mpu/key1 --upload-id ${uploadID} --multipart-upload 'Parts=[${parts}]'  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification                        complete-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/mpu/key1 --upload-id ${uploadID} --multipart-upload 'Parts=[${parts}]'  ${correct_owner}
+
+    # create another MPU to test abort-multipart-upload
+    ${uploadID}=    Execute AWSS3APICli using bucket ownership verification        create-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/mpu/aborttest    ${correct_owner}
+    ${uploadID}=    Execute and checkrc                                            echo '${uploadID}' | jq -r '.UploadId'    0
+
+    Execute AWSS3APICli and failed bucket ownership verification                   abort-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/mpu/aborttest --upload-id ${uploadID}  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification                        abort-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/mpu/aborttest --upload-id ${uploadID}  ${correct_owner}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -63,3 +63,14 @@ Test buckets named like web endpoints
         Create bucket with name    ${name}
         Put object to bucket    bucket=${name}    key=testkey    path=${path}
     END
+
+Check bucket ownership verification
+    [tags]    bucket-ownership-verification
+    ${bucket} =           Create bucket
+    ${correct_owner} =    Get bucket owner    ${bucket}
+
+    Execute AWSS3APICli and failed bucket ownership verification   put-bucket-acl --bucket ${bucket} --grant-full-control id=${correct_owner}  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification        put-bucket-acl --bucket ${bucket} --grant-full-control id=${correct_owner}  ${correct_owner}
+
+    Execute AWSS3APICli and failed bucket ownership verification   get-bucket-acl --bucket ${bucket}    wrong-owner
+    Execute AWSS3APICli using bucket ownership verification        get-bucket-acl --bucket ${bucket}    ${correct_owner}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketdelete.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketdelete.robot
@@ -59,3 +59,11 @@ Delete bucket with incomplete multipart uploads
     # after aborting the multipart upload, the bucket deletion should succeed
     ${abort_result} =          Abort MPU    ${bucket}    incomplete-multipartkey    ${uploadID}
     ${delete_result} =         Execute AWSS3APICli and checkrc    delete-bucket --bucket ${bucket}    0
+
+Check bucket ownership verification
+    [tags]    bucket-ownership-verification
+    ${bucket} =           Create bucket to be deleted
+    ${correct_owner} =    Get bucket owner    ${bucket}
+
+    Execute AWSS3APICli and failed bucket ownership verification  delete-bucket --bucket ${bucket}  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification       delete-bucket --bucket ${bucket}  ${correct_owner}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
@@ -38,3 +38,9 @@ Head Bucket not existent
                         Should contain          ${result}    404
                         Should contain          ${result}    Not Found
 
+Check bucket ownership verification
+    ${result} =  Execute AWSS3APICli and checkrc              head-bucket --bucket ${BUCKET} --expected-bucket-owner wrong-owner  255
+                 Should contain                               ${result}  403
+
+    ${correct_owner} =    Get bucket owner                    ${BUCKET}
+    Execute AWSS3APICli using bucket ownership verification   head-bucket --bucket ${BUCKET}    ${correct_owner}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
@@ -191,3 +191,21 @@ Revoke S3 secrets
     Execute and Ignore Error             ozone s3 revokesecret -y -u testuser
     Execute and Ignore Error             ozone s3 revokesecret -y -u testuser2
 
+Get bucket owner
+    [arguments]    ${bucket}
+    ${owner} =     Execute     ozone sh bucket info /s3v/${bucket} | jq -r '.owner'
+    [return]       ${owner}
+
+Execute AWSS3APICli using bucket ownership verification
+    [arguments]    ${command}    ${expected_bucket_owner}    ${expected_source_bucket_owner}=${EMPTY}
+    ${cmd} =       Set Variable           ${command} --expected-bucket-owner ${expected_bucket_owner}
+    ${cmd} =       Set Variable If        '${expected_source_bucket_owner}' != '' and '${expected_source_bucket_owner}' != '${EMPTY}'    ${cmd} --expected-source-bucket-owner ${expected_source_bucket_owner}    ${cmd}
+    ${result} =    Execute AWSS3APICli    ${cmd}
+    [return]       ${result}
+
+Execute AWSS3APICli and failed bucket ownership verification
+    [arguments]    ${command}    ${wrong_bucket_owner}    ${wrong_source_bucket_owner}=${EMPTY}
+    ${cmd} =       Set Variable           ${command} --expected-bucket-owner ${wrong_bucket_owner}
+    ${cmd} =       Set Variable If        '${wrong_source_bucket_owner}' != '' and '${wrong_source_bucket_owner}' != '${EMPTY}'    ${cmd} --expected-source-bucket-owner ${wrong_source_bucket_owner}    ${cmd}
+    ${result} =    Execute AWSS3APICli and ignore error    ${cmd}
+    Should contain      ${result}         Access Denied

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
@@ -115,3 +115,14 @@ Copy Object with user defined metadata size larger than 2 KB
     ${custom_metadata_value} =  Generate Random String    3000
     ${result} =                 Execute AWSS3ApiCli and checkrc       copy-object --bucket ${DESTBUCKET} --key ${PREFIX}/copyobject/key=value/f1 --copy-source ${BUCKET}/${PREFIX}/copyobject/key=value/f1 --metadata="custom-key1=${custom_metadata_value}" --metadata-directive REPLACE       255
                                 Should contain                        ${result}   MetadataTooLarge
+
+Check Bucket Ownership Verification
+    Run Keyword if      '${DESTBUCKET}' == 'generated1'    Create Dest Bucket
+    Execute              echo "Randomtext" > /tmp/testfile
+    ${correct_owner} =   Get bucket owner    ${DESTBUCKET}
+
+    ${result} =    Execute AWSS3ApiCli                            put-object --bucket ${BUCKET} --key ${PREFIX}/copyowner/key=value/f1 --body /tmp/testfile
+    Execute AWSS3APICli and failed bucket ownership verification  copy-object --bucket ${DESTBUCKET} --key ${PREFIX}/copyowner/key=value/f1 --copy-source ${BUCKET}/${PREFIX}/copyowner/key=value/f1  wrong-owner       ${correct_owner}
+    Execute AWSS3APICli and failed bucket ownership verification  copy-object --bucket ${DESTBUCKET} --key ${PREFIX}/copyowner/key=value/f1 --copy-source ${BUCKET}/${PREFIX}/copyowner/key=value/f1  ${correct_owner}  wrong-owner
+
+    Execute AWSS3APICli using bucket ownership verification       copy-object --bucket ${DESTBUCKET} --key ${PREFIX}/copyowner/key=value/f1 --copy-source ${BUCKET}/${PREFIX}/copyowner/key=value/f1  ${correct_owner}  ${correct_owner}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectdelete.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectdelete.robot
@@ -69,3 +69,23 @@ Delete file with s3api, file doesn't exist, prefix of a real file
 Delete file with s3api, bucket doesn't exist
     ${result} =         Execute AWSS3APICli and checkrc   delete-object --bucket ${BUCKET}-nosuchbucket --key f1      255
                         Should contain                    ${result}         NoSuchBucket
+
+Check Bucket Ownership Verification
+    Execute             echo "Randomtext" > /tmp/testfile
+    ${result} =         Execute AWSS3APICli and checkrc                 put-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 --body /tmp/testfile   0
+    ${correct_owner} =    Get bucket owner                              ${BUCKET}
+    # delete single object
+    Execute AWSS3APICli and failed bucket ownership verification        delete-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification             delete-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1  ${correct_owner}
+
+    # delete multiple objects
+    Execute                                                             echo "Randomtext" > /tmp/testfile1
+    Execute                                                             echo "Randomtext" > /tmp/testfile2
+    Execute AWSS3APICli and checkrc                                     put-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/multi1 --body /tmp/testfile1   0
+    Execute AWSS3APICli and checkrc                                     put-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/multi2 --body /tmp/testfile2   0
+
+    ${delete_json} =    Set Variable                                    {"Objects": [{"Key": "${PREFIX}/bucketownercondition/key=value/multi1"}, {"Key": "${PREFIX}/bucketownercondition/key=value/multi2"}]}
+    ${delete_file} =    Set Variable                                    /tmp/delete_objects.json
+    Execute                                                             echo '${delete_json}' > ${delete_file}
+    Execute AWSS3APICli and failed bucket ownership verification        delete-objects --bucket ${BUCKET} --delete file://${delete_file}  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification             delete-objects --bucket ${BUCKET} --delete file://${delete_file}  ${correct_owner}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objecthead.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objecthead.robot
@@ -61,3 +61,13 @@ Head non existing key
     ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/non-existent   255
                         Should contain          ${result}    404
                         Should contain          ${result}    Not Found
+
+Check Bucket Ownership Verification
+    Execute                                                  echo "Randomtext" > /tmp/testfile
+    ${result} =  Execute AWSS3APICli and checkrc             put-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 --body /tmp/testfile   0
+
+    ${result} =  Execute AWSS3APICli and checkrc             head-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 --expected-bucket-owner wrong-owner  255
+                 Should contain                              ${result}  403
+
+    ${correct_owner} =    Get bucket owner                   ${BUCKET}
+    Execute AWSS3APICli using bucket ownership verification  head-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1    ${correct_owner}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectlist.robot
@@ -64,3 +64,10 @@ List objects with max-keys less than config limit should return correct count
     ${count}=     Execute and checkrc    jq -r '.Contents | length' ${tmpfile}    0
     Should Be True    ${count} == 500
     Remove File   ${tmpfile}
+
+Check Bucket Ownership Verification
+    Prepare Many Objects In Bucket                                1
+    ${correct_owner} =    Get bucket owner                        ${BUCKET}
+
+    Execute AWSS3APICli and failed bucket ownership verification  list-objects-v2 --bucket ${BUCKET}  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification       list-objects-v2 --bucket ${BUCKET}  ${correct_owner}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
@@ -303,3 +303,19 @@ Create&Download big file by multipart upload and get file not existed part numbe
                                 Execute AWSS3Cli           rm s3://${BUCKET}/big_file
                                 Execute                    rm -rf /tmp/big_file
                                 Execute                    rm -rf /tmp/big_file_1
+
+Check Bucket Ownership Verification
+    Execute             echo "Randomtext" > /tmp/testfile
+    ${correct_owner} =    Get bucket owner    ${BUCKET}
+    # test put
+    Execute AWSS3APICli and failed bucket ownership verification    put-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 --body /tmp/testfile  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification         put-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 --body /tmp/testfile  ${correct_owner}
+
+    # test get
+    Execute AWSS3APICli and failed bucket ownership verification    get-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 /tmp/testfile  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification         get-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 /tmp/testfile  ${correct_owner}
+
+    # create directory
+    Execute                                                         touch /tmp/emptyfile
+    Execute AWSS3APICli and failed bucket ownership verification    put-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/dir/ --body /tmp/emptyfile  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification         put-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/dir/ --body /tmp/emptyfile  ${correct_owner}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objecttagging.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objecttagging.robot
@@ -71,3 +71,21 @@ Delete object tagging
                          Should contain             ${result}   TagSet
      ${tagCount} =       Execute and checkrc        echo '${result}' | jq '.TagSet | length'    0
                          Should Be Equal            ${tagCount}    0
+
+Check Bucket Ownership Verification
+    #Create object
+    Execute                                                         echo "Randomtext" > /tmp/testfile
+    Execute AWSS3APICli                                             put-object --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 --body /tmp/testfile
+    ${correct_owner} =    Get bucket owner    ${BUCKET}
+
+    #Create tagging
+    Execute AWSS3APICli and failed bucket ownership verification    put-object-tagging --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 --tagging '{"TagSet": [{ "Key": "tag-key1", "Value": "tag-value1" }]}'  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification         put-object-tagging --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1 --tagging '{"TagSet": [{ "Key": "tag-key1", "Value": "tag-value1" }]}'  ${correct_owner}
+
+    #Get object tagging
+    Execute AWSS3APICli and failed bucket ownership verification    get-object-tagging --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification         get-object-tagging --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1  ${correct_owner}
+
+    #Delete object tagging
+    Execute AWSS3APICli and failed bucket ownership verification    delete-object-tagging --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1  wrong-owner
+    Execute AWSS3APICli using bucket ownership verification         delete-object-tagging --bucket ${BUCKET} --key ${PREFIX}/bucketownercondition/key=value/f1  ${correct_owner}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add smoke tests to verify the bucket owner condition for the following S3 requests:
* GetBucketAcl
* ListMultipartUpload
* ListObject
* PutAcl
* HeadBucket
* DeleteBucket
* MultiDelete (Multi Object Delete)
* CreateKey
* PutObjectTagging
* CreateMultipartKey
* CreateMultipartByCopy
* CopyObject
* CreateDirectory
* GetKey
* GetObjectTagging
* ListPart
* HeadKey
* DeleteKey
* DeleteObjectTagging
* AbortMultipartUpload
* InitMultipartUpload
* CompleteMultipartUpload


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-13260
## How was this patch tested?
