### PR TITLE
HDDS-11765. ContainerChecksumTreeManager to handle missed block deletions from the deleted block ids

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/checksum/ContainerChecksumTreeManager.java
@@ -202,7 +202,7 @@ public class ContainerChecksumTreeManager {
         // Our block deleting service will eventually catch up.
         // Our container scanner will not update this deleted block in the merkle tree further even if it is still on
         // disk so that we remain in sync with the peer.
-        // TODO HDDS-11765 Add support for deleting blocks from our replica when a peer has already deleted the block.
+        // Actual block data and chunk file deletion is handled in KeyValueHandler.reconcileContainerInternal.
         report.addDivergedDeletedBlock(peerBlockMerkleTree);
       } else {
         // Neither our nor peer's block is deleted. Walk the chunk list to find differences.


### PR DESCRIPTION
## What changes were proposed in this pull request?
`ContainerChecksumTreeManager` to handle missed block deletions from the deleted block ids.

Please describe your PR in detail:
During reconciliation with a peer, if deleted blocks are present on the peer but still exist locally, those blocks are deleted locally as well. This addresses cases where replicas may miss block delete transactions from SCM.

* Introduce a `deleteBlockForReconciliation` method that invokes existing APIs (`deleteBlock`, `deleteUnreferenced`) to perform physical deletion and remove related metadata from RocksDB when necessary.
* Add unit and integration tests.
* Generated-by: GitHub Copilot with Claude Opus 4.6 (with manual tweaks)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11765

## How was this patch tested?
https://github.com/hevinhsu/ozone/actions/runs/22558617239