### PR TITLE
HDDS-15032. Return InvalidDigest instead of BadDigest for malformed Content-MD5 header

### DIFF
--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -88,6 +88,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -101,6 +102,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -121,6 +123,7 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.s3.S3ClientFactory;
 import org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils;
 import org.apache.hadoop.ozone.s3.endpoint.S3Owner;
+import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.NonHATests;
@@ -133,6 +136,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -513,17 +518,24 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
     assertEquals("37b51d194a7513e45b56f6524f2d51f2", object.getObjectMetadata().getETag());
   }
 
-  @Test
-  public void testPutObjectWithWrongMD5Header() throws Exception {
+  static Stream<Arguments> wrongContentMD5Provider() throws Exception {
+    byte[] wrongContentBytes = "wrong".getBytes(StandardCharsets.UTF_8);
+    byte[] wrongMd5Bytes = MessageDigest.getInstance("MD5").digest(wrongContentBytes);
+    String wrongMd5Base64 = Base64.getEncoder().encodeToString(wrongMd5Bytes);
+
+    return Stream.of(
+        Arguments.of(wrongMd5Base64, S3ErrorTable.BAD_DIGEST.getCode()),
+        Arguments.of("invalid-base64", S3ErrorTable.INVALID_DIGEST.getCode())
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("wrongContentMD5Provider")
+  public void testPutObjectWithWrongMD5Header(String wrongMd5Base64, String expectedErrorCode) {
     final String bucketName = getBucketName();
     final String keyName = getKeyName();
     final String content = "bar";
     s3Client.createBucket(bucketName);
-
-    // Use wrong content to calculate MD5
-    byte[] wrongContentBytes = "wrong".getBytes(StandardCharsets.UTF_8);
-    byte[] wrongMd5Bytes = calculateDigest(new ByteArrayInputStream(wrongContentBytes), 0, wrongContentBytes.length);
-    String wrongMd5Base64 = Base64.getEncoder().encodeToString(wrongMd5Bytes);
 
     byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
     InputStream is = new ByteArrayInputStream(contentBytes);
@@ -536,7 +548,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
 
     assertEquals(ErrorType.Client, ase.getErrorType());
     assertEquals(400, ase.getStatusCode());
-    assertEquals("BadDigest", ase.getErrorCode());
+    assertEquals(expectedErrorCode, ase.getErrorCode());
 
     // Verify the object was not uploaded
     assertFalse(s3Client.doesObjectExist(bucketName, keyName));
@@ -597,8 +609,9 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
     }
   }
 
-  @Test
-  public void testMultipartUploadPartWithWrongMD5Header() throws Exception {
+  @ParameterizedTest
+  @MethodSource("wrongContentMD5Provider")
+  public void testMultipartUploadPartWithWrongMD5Header(String wrongMd5Base64, String expectedErrorCode) {
     final String bucketName = getBucketName();
     final String keyName = getKeyName();
     s3Client.createBucket(bucketName);
@@ -612,11 +625,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
     String partContent = "partdata";
     byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
 
-    byte[] wrongMd5Bytes = calculateDigest(
-        new ByteArrayInputStream("wrongdata".getBytes(StandardCharsets.UTF_8)), 0, 9);
-    String wrongMd5Base64 = Base64.getEncoder().encodeToString(wrongMd5Bytes);
-
-    // Upload part with wrong MD5 should fail
+    // Upload part with wrong/invalid MD5 should fail
     InputStream partInputStream = new ByteArrayInputStream(partBytes);
     ObjectMetadata metadata = new ObjectMetadata();
     metadata.setContentMD5(wrongMd5Base64);
@@ -636,7 +645,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase implements NonH
 
     assertEquals(ErrorType.Client, ase.getErrorType());
     assertEquals(400, ase.getStatusCode());
-    assertEquals("BadDigest", ase.getErrorCode());
+    assertEquals(expectedErrorCode, ase.getErrorCode());
 
     // Abort the multipart upload
     AbortMultipartUploadRequest abortRequest = new AbortMultipartUploadRequest(bucketName, keyName, uploadId);

--- a/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
+++ b/hadoop-ozone/integration-test-s3/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v2/AbstractS3SDKV2Tests.java
@@ -43,6 +43,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,6 +53,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -71,6 +73,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.s3.S3ClientFactory;
 import org.apache.hadoop.ozone.s3.awssdk.S3SDKTestUtils;
 import org.apache.hadoop.ozone.s3.endpoint.S3Owner;
+import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.s3.util.S3Consts;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.NonHATests;
@@ -84,6 +87,9 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -516,26 +522,33 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     assertEquals("\"37b51d194a7513e45b56f6524f2d51f2\"", getObjectResponse.eTag());
   }
 
-  @Test
-  public void testPutObjectWithWrongMD5Header() throws Exception {
+  static Stream<Arguments> wrongContentMD5Provider() throws Exception {
+    byte[] wrongContentBytes = "wrong".getBytes(StandardCharsets.UTF_8);
+    byte[] wrongMd5Bytes = MessageDigest.getInstance("MD5").digest(wrongContentBytes);
+    String wrongMd5Base64 = Base64.getEncoder().encodeToString(wrongMd5Bytes);
+
+    return Stream.of(
+        Arguments.of(wrongMd5Base64, S3ErrorTable.BAD_DIGEST.getCode()),
+        Arguments.of("invalid-base64", S3ErrorTable.INVALID_DIGEST.getCode())
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("wrongContentMD5Provider")
+  public void testPutObjectWithWrongMD5Header(String contentMD5, String expectedErrorCode) {
     final String bucketName = getBucketName();
     final String keyName = getKeyName();
     final String content = "bar";
     s3Client.createBucket(b -> b.bucket(bucketName));
 
-    // Use wrong content to calculate MD5
-    byte[] wrongContentBytes = "wrong".getBytes(StandardCharsets.UTF_8);
-    byte[] wrongMd5Bytes = calculateDigest(new ByteArrayInputStream(wrongContentBytes), 0, wrongContentBytes.length);
-    String wrongMd5Base64 = Base64.getEncoder().encodeToString(wrongMd5Bytes);
-
     S3Exception exception = assertThrows(S3Exception.class, () -> s3Client.putObject(b -> b
             .bucket(bucketName)
             .key(keyName)
-            .contentMD5(wrongMd5Base64),
+            .contentMD5(contentMD5),
         RequestBody.fromString(content)));
 
     assertEquals(400, exception.statusCode());
-    assertEquals("BadDigest", exception.awsErrorDetails().errorCode());
+    assertEquals(expectedErrorCode, exception.awsErrorDetails().errorCode());
 
     // Verify the object was not uploaded
     assertThrows(NoSuchKeyException.class, () -> s3Client.headObject(b -> b.bucket(bucketName).key(keyName)));
@@ -591,8 +604,9 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     assertEquals(part1Content, objectBytes.asUtf8String());
   }
 
-  @Test
-  public void testMultipartUploadPartWithWrongMD5Header() throws Exception {
+  @ParameterizedTest
+  @MethodSource("wrongContentMD5Provider")
+  public void testMultipartUploadPartWithWrongMD5Header(String wrongMd5Base64, String expectedErrorCode) {
     final String bucketName = getBucketName();
     final String keyName = getKeyName();
     s3Client.createBucket(b -> b.bucket(bucketName));
@@ -607,10 +621,6 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
     String partContent = "partdata";
     byte[] partBytes = partContent.getBytes(StandardCharsets.UTF_8);
 
-    byte[] wrongMd5Bytes = calculateDigest(
-        new ByteArrayInputStream("wrongdata".getBytes(StandardCharsets.UTF_8)), 0, 9);
-    String wrongMd5Base64 = Base64.getEncoder().encodeToString(wrongMd5Bytes);
-
     // Upload part with wrong MD5 should fail
     S3Exception exception = assertThrows(S3Exception.class, () -> s3Client.uploadPart(b -> b
             .bucket(bucketName)
@@ -621,7 +631,7 @@ public abstract class AbstractS3SDKV2Tests extends OzoneTestBase implements NonH
         RequestBody.fromBytes(partBytes)));
 
     assertEquals(400, exception.statusCode());
-    assertEquals("BadDigest", exception.awsErrorDetails().errorCode());
+    assertEquals(expectedErrorCode, exception.awsErrorDetails().errorCode());
 
     // Abort the multipart upload
     s3Client.abortMultipartUpload(b -> b

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -164,7 +164,10 @@ public enum S3ErrorTable {
 
   BAD_DIGEST(
       "BadDigest", "The Content-MD5 or checksum value that you specified did not match what the server received.",
-      HTTP_BAD_REQUEST);
+      HTTP_BAD_REQUEST),
+
+  INVALID_DIGEST(
+      "InvalidDigest", "The Content-MD5 you specified is not valid.", HTTP_BAD_REQUEST);
 
   private static final Logger LOG = LoggerFactory.getLogger(S3ErrorTable.class);
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.s3.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BAD_DIGEST;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_DIGEST;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_STORAGE_CLASS;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.AWS_CHUNKED;
@@ -242,23 +243,34 @@ public final class S3Utils {
   /**
    * Validates the Content-MD5 header against the actual MD5 hash.
    *
+   * <p>Throws {@link org.apache.hadoop.ozone.s3.exception.S3ErrorTable#INVALID_DIGEST}
+   * when the Content-MD5 header is absent, contains an invalid Base64 string,
+   * or decodes to a byte array that is not exactly 16 bytes (i.e. not a valid
+   * MD5 digest).  Throws
+   * {@link org.apache.hadoop.ozone.s3.exception.S3ErrorTable#BAD_DIGEST}
+   * when the header is well-formed but does not match the computed hash.
+   *
    * @param clientMD5 the base64-encoded MD5 from Content-MD5 header
    * @param serverMD5 the hex-encoded MD5 hash of the data
    * @param resource  the resource path for error messages
-   * @throws OS3Exception if the MD5 values do not match
+   * @throws OS3Exception if the Content-MD5 is invalid or does not match
    */
   public static void validateContentMD5(String clientMD5, String serverMD5, String resource)
       throws OS3Exception {
     if (clientMD5 == null) {
-      throw newError(BAD_DIGEST, resource);
+      throw newError(INVALID_DIGEST, resource);
     }
 
     try {
-      if (!Hex.encodeHexString(Base64.getDecoder().decode(clientMD5)).equals(serverMD5)) {
+      byte[] decoded = Base64.getDecoder().decode(clientMD5);
+      if (decoded.length != 16) {
+        throw newError(INVALID_DIGEST, resource);
+      }
+      if (!Hex.encodeHexString(decoded).equals(serverMD5)) {
         throw newError(BAD_DIGEST, resource);
       }
     } catch (IllegalArgumentException ex) {
-      throw newError(BAD_DIGEST, resource);
+      throw newError(INVALID_DIGEST, resource);
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -533,21 +533,21 @@ class TestObjectPut {
     byte[] wrongMd5Bytes = MessageDigest.getInstance("MD5").digest(wrongContentBytes);
     String wrongMd5Base64 = Base64.getEncoder().encodeToString(wrongMd5Bytes);
     return Stream.of(
-        Arguments.arguments(wrongMd5Base64),
-        Arguments.arguments("invalid-base64")
+        Arguments.arguments(wrongMd5Base64, S3ErrorTable.BAD_DIGEST),
+        Arguments.arguments("invalid-base64", S3ErrorTable.INVALID_DIGEST)
     );
   }
 
   @ParameterizedTest
   @MethodSource("wrongContentMD5Provider")
-  public void testPutObjectWithWrongContentMD5(String wrongContentMD5) throws Exception {
+  public void testPutObjectWithWrongContentMD5(String wrongContentMD5, S3ErrorTable s3Error) throws Exception {
 
     // WHEN
     when(headers.getHeaderString("Content-MD5")).thenReturn(wrongContentMD5);
 
     // WHEN/THEN
-    OS3Exception ex = assertErrorResponse(S3ErrorTable.BAD_DIGEST, () -> putObject(CONTENT));
-    assertThat(ex.getErrorMessage()).contains(S3ErrorTable.BAD_DIGEST.getErrorMessage());
+    OS3Exception ex = assertErrorResponse(s3Error, () -> putObject(CONTENT));
+    assertThat(ex.getErrorMessage()).contains(s3Error.getErrorMessage());
   }
 
   private HttpHeaders newMockHttpHeaders() {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -221,14 +221,14 @@ public class TestPartUpload {
     byte[] wrongMd5Bytes = MessageDigest.getInstance("MD5").digest(wrongContentBytes);
     String wrongMd5Base64 = Base64.getEncoder().encodeToString(wrongMd5Bytes);
     return Stream.of(
-        Arguments.arguments(wrongMd5Base64),
-        Arguments.arguments("invalid-base64")
+        Arguments.arguments(wrongMd5Base64, S3ErrorTable.BAD_DIGEST),
+        Arguments.arguments("invalid-base64", S3ErrorTable.INVALID_DIGEST)
     );
   }
 
   @ParameterizedTest
   @MethodSource("wrongContentMD5Provider")
-  public void testPartUploadWithWrongContentMD5(String wrongContentMD5) throws Exception {
+  public void testPartUploadWithWrongContentMD5(String wrongContentMD5, S3ErrorTable s3Error) throws Exception {
     String content = "Multipart Upload Part";
 
     HttpHeaders headersWithWrongMD5 = mock(HttpHeaders.class);
@@ -243,7 +243,7 @@ public class TestPartUpload {
 
     String uploadID = initiateMultipartUpload(endpoint, OzoneConsts.S3_BUCKET, OzoneConsts.KEY);
 
-    assertErrorResponse(S3ErrorTable.BAD_DIGEST,
+    assertErrorResponse(s3Error,
         () -> put(endpoint, OzoneConsts.S3_BUCKET, OzoneConsts.KEY, 1, uploadID, content));
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestS3Utils.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestS3Utils.java
@@ -17,13 +17,19 @@
 
 package org.apache.hadoop.ozone.s3.util;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
+import java.util.stream.Stream;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -146,6 +152,41 @@ public class TestS3Utils {
   @Test
   public void testGenerateCanonicalUserId() {
     assertEquals(S3Owner.DEFAULT_S3OWNER_ID, S3Utils.generateCanonicalUserId("ozone"));
+  }
+
+  static Stream<Arguments> wrongContentMD5Provider() throws Exception {
+    String serverMD5 = Hex.encodeHexString(
+        MessageDigest.getInstance("MD5").digest("bar".getBytes(StandardCharsets.UTF_8)));
+
+    byte[] wrongMd5Bytes = MessageDigest.getInstance("MD5").digest("wrong".getBytes(StandardCharsets.UTF_8));
+    String wrongMd5Base64 = Base64.getEncoder().encodeToString(wrongMd5Bytes);
+
+    String shortBase64 = Base64.getEncoder().encodeToString("hello".getBytes(StandardCharsets.UTF_8));
+
+    return Stream.of(
+        Arguments.of(null, serverMD5, S3ErrorTable.INVALID_DIGEST.getCode()),
+        Arguments.of("wrong-base64", serverMD5, S3ErrorTable.INVALID_DIGEST.getCode()),
+        Arguments.of(shortBase64, serverMD5, S3ErrorTable.INVALID_DIGEST.getCode()),
+        Arguments.of(wrongMd5Base64, serverMD5, S3ErrorTable.BAD_DIGEST.getCode())
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("wrongContentMD5Provider")
+  public void testValidateContentMD5WithInvalidInput(
+      String clientMD5, String serverMD5, String expectedErrorCode) {
+    OS3Exception ex = assertThrows(OS3Exception.class,
+        () -> S3Utils.validateContentMD5(clientMD5, serverMD5, "test-resource"));
+    assertEquals(expectedErrorCode, ex.getCode());
+  }
+
+  @Test
+  public void testValidateContentMD5WithValidInput() throws Exception {
+    byte[] md5Bytes = MessageDigest.getInstance("MD5").digest("bar".getBytes(StandardCharsets.UTF_8));
+    String md5Base64 = Base64.getEncoder().encodeToString(md5Bytes);
+    String md5Hex = Hex.encodeHexString(md5Bytes);
+
+    assertDoesNotThrow(() -> S3Utils.validateContentMD5(md5Base64, md5Hex, "test-resource"));
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR updates the S3 Gateway error handling logic to return the `InvalidDigest` error code instead of `BadDigest` when a malformed `Content-MD5` header is encountered.

## Please describe your PR in detail:
* Add `InvalidDigest` error.
* Validate the `Content-MD5` header and return `InvalidDigest` when it is malformed (e.g. invalid Base64) or its decoded length is not 16 bytes.

## What is the link to the Apache JIRA?
https://issues.apache.org/jira/browse/HDDS-15032

## How was this patch tested?
* green ci: https://github.com/hevinhsu/ozone/actions/runs/24383695714
* Verified locally using ceph s3-tests:
  - [test_object_create_bad_md5_invalid_short](https://github.com/ceph/s3-tests/blob/master/s3tests/functional/test_headers.py#L158)
  - [test_object_create_bad_md5_empty](https://github.com/ceph/s3-tests/blob/master/s3tests/functional/test_headers.py#L158)